### PR TITLE
Update for epsilon master (1.8.0_beta)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-snapshots += Rpn::App::Snapshot
-snapshot_headers += apps/rpn/app.h
+apps += Rpn::App
+app_headers += apps/rpn/app.h
 
 app_objs += $(addprefix apps/rpn/,\
   app.o\

--- a/app.cpp
+++ b/app.cpp
@@ -23,7 +23,9 @@ App::Snapshot::Snapshot()
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new App(container, this);
+  App * app = new App(container, this);
+  m_rpnStack.unpack();
+  return app;
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -33,6 +35,10 @@ App::Descriptor * App::Snapshot::descriptor() {
 
 RpnStack * App::Snapshot::rpnStack() {
   return &m_rpnStack;
+}
+
+void App::Snapshot::tidy() {
+  m_rpnStack.tidy();
 }
 
 void App::Snapshot::reset() {

--- a/app.h
+++ b/app.h
@@ -24,6 +24,7 @@ public:
     Descriptor * descriptor() override;
     RpnStack * rpnStack();
   private:
+    void tidy() override;
     RpnStack m_rpnStack;
   };
 private:

--- a/rpn_prompt_controller.cpp
+++ b/rpn_prompt_controller.cpp
@@ -161,10 +161,15 @@ bool RpnPromptController::handleEventSpecial(Ion::Events::Event event) {
 
 bool RpnPromptController::handleEventOperation(Ion::Events::Event event) {
 
-  if (!pushInput())
+  if (!(event == Ion::Events::Plus || event == Ion::Events::Minus || event == Ion::Events::Multiplication || event == Ion::Events::Division || event == Ion::Events::Space ||
+        event == Ion::Events::Sine || event == Ion::Events::Cosine || event == Ion::Events::Tangent ||
+        event == Ion::Events::Arcsine || event == Ion::Events::Arccosine || event == Ion::Events::Arctangent ||
+        event == Ion::Events::Ln || event == Ion::Events::Log || event == Ion::Events::Exp ||
+        event == Ion::Events::Sqrt || event == Ion::Events::Square || event == Ion::Events::Power)) {
     return false;
+  }
 
-  if (!m_rpnStack->length())
+  if (!pushInput())
     return false;
 
   /* binary */

--- a/rpn_prompt_controller.cpp
+++ b/rpn_prompt_controller.cpp
@@ -175,35 +175,30 @@ bool RpnPromptController::handleEventOperation(Ion::Events::Event event) {
   /* binary */
 
   if (event == Ion::Events::Plus) {
-    if (m_rpnStack->length() < 2) return false;
     Expression *e = new Addition((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Minus) {
-    if (m_rpnStack->length() < 2) return false;
     Expression *e = new Subtraction((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Multiplication) {
-    if (m_rpnStack->length() < 2) return false;
     Expression *e = new Multiplication((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Division) {
-    if (m_rpnStack->length() < 2) return false;
     Expression *e = new Division((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Power) {
-    if (m_rpnStack->length() < 2) return false;
     Expression *e = new Power((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->pop();
@@ -212,73 +207,61 @@ bool RpnPromptController::handleEventOperation(Ion::Events::Event event) {
   /* unary */
 
   } else if (event == Ion::Events::Space) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new Opposite((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Sine) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new Sine((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Cosine) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new Cosine((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Tangent) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new Tangent((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Arcsine) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new ArcSine((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Arccosine) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new ArcCosine((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Arctangent) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new ArcTangent((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Ln) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new NaperianLogarithm((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Log) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new Logarithm((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Exp) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new Power(Symbol(Ion::Charset::Exponential), (*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Sqrt) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new SquareRoot((*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Square) {
-    if (m_rpnStack->length() < 1) return false;
     Expression *e = new Power(Rational(2), (*m_rpnStack)[0].clone());
     m_rpnStack->pop();
     m_rpnStack->push(e);

--- a/rpn_prompt_controller.cpp
+++ b/rpn_prompt_controller.cpp
@@ -164,81 +164,119 @@ bool RpnPromptController::handleEventOperation(Ion::Events::Event event) {
   if (!pushInput())
     return false;
 
-  if (!m_rpnStack->length()) {
+  if (!m_rpnStack->length())
     return false;
-
 
   /* binary */
 
-  } else if (event == Ion::Events::Plus) {
+  if (event == Ion::Events::Plus) {
     if (m_rpnStack->length() < 2) return false;
-    m_rpnStack->push(new Addition(m_rpnStack->pop(), m_rpnStack->pop()));
+    Expression *e = new Addition((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Minus) {
     if (m_rpnStack->length() < 2) return false;
-    m_rpnStack->push(new Subtraction(m_rpnStack->pop(), m_rpnStack->pop()));
+    Expression *e = new Subtraction((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Multiplication) {
     if (m_rpnStack->length() < 2) return false;
-    m_rpnStack->push(new Multiplication(m_rpnStack->pop(), m_rpnStack->pop()));
+    Expression *e = new Multiplication((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Division) {
     if (m_rpnStack->length() < 2) return false;
-    m_rpnStack->push(new Division(m_rpnStack->pop(), m_rpnStack->pop()));
+    Expression *e = new Division((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Power) {
     if (m_rpnStack->length() < 2) return false;
-    m_rpnStack->push(new Power(m_rpnStack->pop(), m_rpnStack->pop()));
+    Expression *e = new Power((*m_rpnStack)[1].clone(), (*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   /* unary */
 
   } else if (event == Ion::Events::Space) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new Opposite(m_rpnStack->pop()));
+    Expression *e = new Opposite((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Sine) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new Sine(m_rpnStack->pop()));
+    Expression *e = new Sine((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Cosine) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new Cosine(m_rpnStack->pop()));
+    Expression *e = new Cosine((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Tangent) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new Tangent(m_rpnStack->pop()));
+    Expression *e = new Tangent((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Arcsine) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new ArcSine(m_rpnStack->pop()));
+    Expression *e = new ArcSine((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Arccosine) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new ArcCosine(m_rpnStack->pop()));
+    Expression *e = new ArcCosine((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Arctangent) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new ArcTangent(m_rpnStack->pop()));
+    Expression *e = new ArcTangent((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Ln) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new NaperianLogarithm(m_rpnStack->pop()));
+    Expression *e = new NaperianLogarithm((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Log) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new Logarithm(m_rpnStack->pop()));
+    Expression *e = new Logarithm((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Exp) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new Power(Symbol(Ion::Charset::Exponential), m_rpnStack->pop()));
+    Expression *e = new Power(Symbol(Ion::Charset::Exponential), (*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Sqrt) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new SquareRoot(m_rpnStack->pop()));
+    Expression *e = new SquareRoot((*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else if (event == Ion::Events::Square) {
     if (m_rpnStack->length() < 1) return false;
-    m_rpnStack->push(new Power(Rational(2), m_rpnStack->pop()));
+    Expression *e = new Power(Rational(2), (*m_rpnStack)[0].clone());
+    m_rpnStack->pop();
+    m_rpnStack->push(e);
 
   } else {
     return false;

--- a/rpn_stack.cpp
+++ b/rpn_stack.cpp
@@ -18,38 +18,36 @@ RpnStack::~RpnStack() {
 }
 
 void RpnStack::dup() {
-  push(new Poincare::Expression((*this)[0].clone()));
+  push((*this)[0].clone());
 }
 
 void RpnStack::swap() {
-  if (m_length < 2)
-      return;
-
-  Poincare::Expression *tmp = m_stack[m_length - 1];
-  m_stack[m_length - 1] = m_stack[m_length - 2];
-  m_stack[m_length - 2] = tmp;
+  Poincare::Expression * a = (*this)[0].clone();
+  Poincare::Expression * b = (*this)[1].clone();
+  pop();
+  pop();
+  push(a);
+  push(b);
 }
 
 void RpnStack::rot() {
-  if (m_length < 2)
-      return;
-
-  // move everything one element forward
-  Poincare::Expression *tmp, *last = m_stack[0];
-  for (int i = 1; i < m_length; i++) {
-      tmp = m_stack[i];
-      m_stack[i] = last;
-      last = tmp;
-  }
-  m_stack[0] = last;
+  Poincare::Expression * a = (*this)[0].clone();
+  Poincare::Expression * b = (*this)[1].clone();
+  Poincare::Expression * c = (*this)[2].clone();
+  pop();
+  pop();
+  pop();
+  push(b);
+  push(a);
+  push(c);
 }
 
 void RpnStack::over() {
-  push(new Poincare::Expression((*this)[1].clone()));
+  push((*this)[1].clone());
 }
 
 bool RpnStack::push(const char *text) {
-  Poincare::Expression *exp = new Poincare::Expression(Poincare::Expression::parse(text));
+  Poincare::Expression * exp = Poincare::Expression::parse(text);
   if (exp == nullptr) {
     return false;
   }
@@ -58,33 +56,56 @@ bool RpnStack::push(const char *text) {
 }
 
 void RpnStack::push(Poincare::Expression * exp) {
-  if (m_length == k_stackSize)
-      return;
-
-  delete m_stack[m_length];
-  m_stack[m_length] = exp;
-  m_length++;
+  delete m_stack[k_stackSize-1];
+  for (int i = k_stackSize-1; i > 0; i--) {
+    m_stack[i] = m_stack[i-1];
+  }
+  m_stack[0] = exp;
+  m_length += m_length < k_stackSize ? 1 : 0;
 }
 
-Poincare::Expression RpnStack::pop() {
-  if (!m_length)
-      return Poincare::Rational(0);
-
-  m_length--;
-
-  Poincare::Expression e = *m_stack[m_length];
-  delete m_stack[m_length];
-  m_stack[m_length] = new Poincare::Rational(0);
-
-  return e;
+void RpnStack::pop() {
+  delete m_stack[0];
+  for (int i = 0; i < k_stackSize-1; i++) {
+    m_stack[i] = m_stack[i+1];
+  }
+  m_stack[k_stackSize-1] = new Poincare::Rational(0);
+  m_length -= m_length > 0 ? 1 : 0;
 }
 
 void RpnStack::clear() {
   for (int i = 0; i < RpnStack::k_stackSize; i++) {
-      delete m_stack[i];
-      m_stack[i] = new Poincare::Rational(0);
+    this->pop();
   }
-  m_length = 0;
+}
+
+void RpnStack::doOperation(Poincare::DynamicHierarchy * exp) {
+  exp->addOperand((*this)[1].clone());
+  exp->addOperand((*this)[0].clone());
+  pop();
+  pop();
+
+  push(exp);
+}
+
+void RpnStack::doOperation(Poincare::StaticHierarchy<1> * exp) {
+  Poincare::ListData listData;
+  listData.pushExpression((*this)[0].clone());
+  exp->setArgument(&listData, 2, true);
+  pop();
+
+  push(exp);
+}
+
+void RpnStack::doOperation(Poincare::StaticHierarchy<2> * exp) {
+  Poincare::ListData listData;
+  listData.pushExpression((*this)[1].clone());
+  listData.pushExpression((*this)[0].clone());
+  exp->setArgument(&listData, 2, true);
+  pop();
+  pop();
+
+  push(exp);
 }
 
 }

--- a/rpn_stack.cpp
+++ b/rpn_stack.cpp
@@ -18,12 +18,12 @@ RpnStack::~RpnStack() {
 }
 
 void RpnStack::dup() {
-  push((*this)[0].clone());
+  push(new Poincare::Expression((*this)[0].clone()));
 }
 
 void RpnStack::swap() {
-  Poincare::Expression * a = (*this)[0].clone();
-  Poincare::Expression * b = (*this)[1].clone();
+  Poincare::Expression * a = new Poincare::Expression((*this)[0].clone());
+  Poincare::Expression * b = new Poincare::Expression((*this)[1].clone());
   pop();
   pop();
   push(a);
@@ -31,9 +31,9 @@ void RpnStack::swap() {
 }
 
 void RpnStack::rot() {
-  Poincare::Expression * a = (*this)[0].clone();
-  Poincare::Expression * b = (*this)[1].clone();
-  Poincare::Expression * c = (*this)[2].clone();
+  Poincare::Expression * a = new Poincare::Expression((*this)[0].clone());
+  Poincare::Expression * b = new Poincare::Expression((*this)[1].clone());
+  Poincare::Expression * c = new Poincare::Expression((*this)[2].clone());
   pop();
   pop();
   pop();
@@ -43,11 +43,11 @@ void RpnStack::rot() {
 }
 
 void RpnStack::over() {
-  push((*this)[1].clone());
+  push(new Poincare::Expression((*this)[1].clone()));
 }
 
 bool RpnStack::push(const char *text) {
-  Poincare::Expression * exp = Poincare::Expression::parse(text);
+  Poincare::Expression * exp = new Poincare::Expression(Poincare::Expression::parse(text));
   if (exp == nullptr) {
     return false;
   }
@@ -77,35 +77,6 @@ void RpnStack::clear() {
   for (int i = 0; i < RpnStack::k_stackSize; i++) {
     this->pop();
   }
-}
-
-void RpnStack::doOperation(Poincare::DynamicHierarchy * exp) {
-  exp->addOperand((*this)[1].clone());
-  exp->addOperand((*this)[0].clone());
-  pop();
-  pop();
-
-  push(exp);
-}
-
-void RpnStack::doOperation(Poincare::StaticHierarchy<1> * exp) {
-  Poincare::ListData listData;
-  listData.pushExpression((*this)[0].clone());
-  exp->setArgument(&listData, 2, true);
-  pop();
-
-  push(exp);
-}
-
-void RpnStack::doOperation(Poincare::StaticHierarchy<2> * exp) {
-  Poincare::ListData listData;
-  listData.pushExpression((*this)[1].clone());
-  listData.pushExpression((*this)[0].clone());
-  exp->setArgument(&listData, 2, true);
-  pop();
-  pop();
-
-  push(exp);
 }
 
 }

--- a/rpn_stack.cpp
+++ b/rpn_stack.cpp
@@ -1,9 +1,7 @@
 #include "rpn_stack.h"
-#include "../shared/poincare_helpers.h"
+#include "../../poincare/include/poincare_layouts.h"
 #include "ion/charset.h"
 #include <string.h>
-
-using namespace Shared;
 
 namespace Rpn {
 

--- a/rpn_stack.cpp
+++ b/rpn_stack.cpp
@@ -7,7 +7,7 @@ namespace Rpn {
 
 RpnStack::RpnStack() {
   for (int i = 0; i < k_stackSize; i++) {
-    strcpy(m_expressions[i], "0");
+    strlcpy(m_expressions[i], "0", sizeof(*m_expressions));
   }
   m_isPacked = true;
 }

--- a/rpn_stack.h
+++ b/rpn_stack.h
@@ -1,7 +1,8 @@
 #ifndef RPN_STACK_H
 #define RPN_STACK_H
 
-#include "poincare.h"
+#include <escher.h>
+#include <poincare.h>
 #include <stddef.h>
 
 namespace Rpn {
@@ -22,12 +23,18 @@ public:
   void pop();
   void clear();
 
+  void tidy();
+  void unpack();
+
   int length() const { return m_length; }
 
   static constexpr int k_stackSize = 16;
+  constexpr static int k_printedExpressionSize = 2*::TextField::maxBufferSize();
 private:
-  Poincare::Expression * m_stack[k_stackSize];
+  Poincare::Expression *m_stack[k_stackSize];
+  char m_expressions[k_stackSize][k_printedExpressionSize];
   int m_length;
+  bool m_isPacked;
 };
 
 }

--- a/rpn_stack.h
+++ b/rpn_stack.h
@@ -22,10 +22,6 @@ public:
   void pop();
   void clear();
 
-  void doOperation(Poincare::DynamicHierarchy * exp);
-  void doOperation(Poincare::StaticHierarchy<1> * exp);
-  void doOperation(Poincare::StaticHierarchy<2> * exp);
-
   int length() const { return m_length; }
 
   static constexpr int k_stackSize = 16;

--- a/rpn_stack.h
+++ b/rpn_stack.h
@@ -18,19 +18,15 @@ public:
   void rot();
   void over();
   bool push(const char *text);
-  void push(Poincare::Expression * exp);
-  void pop();
+  void push(Poincare::Expression *exp);
+  Poincare::Expression pop();
   void clear();
-
-  void doOperation(Poincare::DynamicHierarchy * exp);
-  void doOperation(Poincare::StaticHierarchy<1> * exp);
-  void doOperation(Poincare::StaticHierarchy<2> * exp);
 
   int length() const { return m_length; }
 
   static constexpr int k_stackSize = 16;
 private:
-  Poincare::Expression * m_stack[k_stackSize];
+  Poincare::Expression *m_stack[k_stackSize];
   int m_length;
 };
 

--- a/rpn_stack.h
+++ b/rpn_stack.h
@@ -18,15 +18,19 @@ public:
   void rot();
   void over();
   bool push(const char *text);
-  void push(Poincare::Expression *exp);
-  Poincare::Expression pop();
+  void push(Poincare::Expression * exp);
+  void pop();
   void clear();
+
+  void doOperation(Poincare::DynamicHierarchy * exp);
+  void doOperation(Poincare::StaticHierarchy<1> * exp);
+  void doOperation(Poincare::StaticHierarchy<2> * exp);
 
   int length() const { return m_length; }
 
   static constexpr int k_stackSize = 16;
 private:
-  Poincare::Expression *m_stack[k_stackSize];
+  Poincare::Expression * m_stack[k_stackSize];
   int m_length;
 };
 

--- a/rpn_stack_controller.cpp
+++ b/rpn_stack_controller.cpp
@@ -27,7 +27,7 @@ bool RpnStackController::handleEvent(Ion::Events::Event event) {
   }
   else if (event == Ion::Events::EXE || event == Ion::Events::OK) {
     char buffer[256];
-    (*m_rpnStack)[m_rpnStack->length() - selectedRow() - 1].writeTextInBuffer(buffer, sizeof(buffer), Poincare::PrintFloat::Mode::Decimal);
+    (*m_rpnStack)[m_rpnStack->length() - selectedRow() - 1].writeTextInBuffer(buffer, sizeof(buffer));
     m_promptController->setText(buffer);
     app()->setFirstResponder(m_promptController);
     return true;
@@ -42,8 +42,8 @@ void RpnStackController::willDisplayCellForIndex(HighlightCell * cell, int index
   EvenOddBufferTextCell *realCell = static_cast<EvenOddBufferTextCell *>(cell);
   realCell->setEven(index%2);
   realCell->setFontSize(KDText::FontSize::Large);
-  e->writeTextInBuffer(buffer, sizeof(buffer), Poincare::PrintFloat::Mode::Decimal);
   Poincare::Expression *e = (&((*m_rpnStack)[m_rpnStack->length() - index - 1]))->approximate<double>(*((Rpn::App*)app())->localContext());
+  e->writeTextInBuffer(buffer, sizeof(buffer));
   delete e;
   realCell->setText(buffer);
   realCell->reloadCell();

--- a/rpn_stack_controller.cpp
+++ b/rpn_stack_controller.cpp
@@ -3,7 +3,7 @@
 #include "app.h"
 #include "rpn_prompt_controller.h"
 #include "../i18n.h"
-#include "../shared/poincare_helpers.h"
+#include "../../poincare/include/poincare_layouts.h"
 #include <assert.h>
 
 namespace Rpn {
@@ -42,8 +42,8 @@ void RpnStackController::willDisplayCellForIndex(HighlightCell * cell, int index
   EvenOddBufferTextCell *realCell = static_cast<EvenOddBufferTextCell *>(cell);
   realCell->setEven(index%2);
   realCell->setFontSize(KDText::FontSize::Large);
-  Poincare::Expression *e = Shared::PoincareHelpers::Approximate<double>(&((*m_rpnStack)[m_rpnStack->length() - index - 1]), *((Rpn::App*)app())->localContext());
   e->writeTextInBuffer(buffer, sizeof(buffer), Poincare::PrintFloat::Mode::Decimal);
+  Poincare::Expression *e = (&((*m_rpnStack)[m_rpnStack->length() - index - 1]))->approximate<double>(*((Rpn::App*)app())->localContext());
   delete e;
   realCell->setText(buffer);
   realCell->reloadCell();


### PR DESCRIPTION
More progress on bringing rpn up-to-date with upstream epsilon. My master branch compiles with the latest epsilon and runs without issue when targeting the simulator.

Unfortunately, I'm having build trouble when targeting real hardware:

```
pps/rpn/rpn_stack.cpp: In constructor 'Rpn::RpnStack::RpnStack()':
apps/rpn/rpn_stack.cpp:10:5: error: 'strcpy' was not declared in this scope
     strcpy(m_expressions[i], "0");
     ^~~~~~
apps/rpn/rpn_stack.cpp:10:5: note: 'strcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
apps/rpn/rpn_stack.cpp:3:1:
+#include <cstring>
 #include "ion/charset.h"
apps/rpn/rpn_stack.cpp:10:5:
     strcpy(m_expressions[i], "0");
     ^~~~~~
make: *** [Makefile:67: apps/rpn/rpn_stack.o] Error 1
```

If I use `<cstring>` and `std::strcpy`, instead of `<string.h>` and `strcpy`, I get a different error:

```
apps/rpn/rpn_stack.cpp:4:10: fatal error: cstring: No such file or directory
 #include <cstring>
          ^~~~~~~~~
compilation terminated.
make: *** [Makefile:67: apps/rpn/rpn_stack.o] Error 1
```

Perhaps I'm just missing the embedded stdlib? Could you try to get this code compiled on your machine? 