### PR TITLE
Fixed a crash in rpn stack

### DIFF
--- a/rpn_stack.cpp
+++ b/rpn_stack.cpp
@@ -259,7 +259,8 @@ void Stack::dropNth(size_t index) {
     for (size_t i = index; i < length(); i++) {
       m_stack[i] = m_stack[i+1];
     }
-    m_length--;
+    m_length -= m_length > 0 ? 1 : 0;
+    m_stack[k_stackSize-1] = Element();
   }
 }
 


### PR DESCRIPTION
Scenario : fill the whole stack, then go up and delete all the stack one element by one. When it's empty, in the input, press 5 +. Here the crash happens.
It didn't appear with pop'ing the stack, so it surely was the dropNth which was wrong.

This seems to fix https://github.com/Lauryy06/Upsilon/issues/45